### PR TITLE
Initial specific orientation for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,15 @@ export default class AppScreen extends Component {
   componentWillMount() {
     // The getOrientation method is async. It happens sometimes that
     // you need the orientation at the moment the JS runtime starts running on device.
-    // `getInitialOrientation` returns directly because its a constant set at the
-    // beginning of the JS runtime.
+    // `getInitialOrientation` or `getInitialSpecificOrientation` returns directly
+    // because its constants set at the beginning of the JS runtime.
 
     const initial = Orientation.getInitialOrientation();
+
+    // Use `getInitialSpecificOrientation` instead of `getInitialOrientation`
+    // to know if its `LANDSCAPE-LEFT` `LANDSCAPE-RIGHT`
+    // const initial = Orientation.getInitialSpecificOrientation();
+
     if (initial === 'PORTRAIT') {
       // do something
     } else {
@@ -219,3 +224,26 @@ removeSpecificOrientationListener((specificOrientation) => {});
 - `unlockAllOrientations()`
 - `getOrientation((err, orientation) => {})`
 - `getSpecificOrientation((err, specificOrientation) => {})`
+
+## Constants
+
+```javascript
+getInitialOrientation;
+```
+
+`orientation` will return one of the following values:
+- `LANDSCAPE`
+- `PORTRAIT`
+- `PORTRAITUPSIDEDOWN`
+- `UNKNOWN`
+
+```javascript
+getInitialSpecificOrientation;
+```
+
+`specificOrientation` will return one of the following values:
+- `LANDSCAPE-LEFT`
+- `LANDSCAPE-RIGHT`
+- `PORTRAIT`
+- `PORTRAITUPSIDEDOWN`
+- `UNKNOWN`

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -127,6 +127,8 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
             constants.put("initialOrientation", orientation);
         }
 
+        constants.put("initialSpecificOrientation", null);
+
         return constants;
     }
 

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -228,9 +228,11 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
 
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   NSString *orientationStr = [self getOrientationStr:orientation];
+  NSString *specificOrientationStr = [self getSpecificOrientationStr:orientation];
 
   return @{
-    @"initialOrientation": orientationStr
+    @"initialOrientation": orientationStr,
+    @"initialSpecificOrientation": specificOrientationStr
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -96,5 +96,9 @@ module.exports = {
 
   getInitialOrientation() {
     return Orientation.initialOrientation;
+  },
+
+  getInitialSpecificOrientation() {
+    return Orientation.initialSpecificOrientation;
   }
 }


### PR DESCRIPTION
Add a constant to get the initial specific orientation on iOS

The method `getInitialOrientation` can only return `LANDSCAPE` and I need to know if it's a `LANDSCAPE-LEFT` or a `LANDSCAPE-RIGHT`

No changes has been made on Android because of I found nothing related to specificOrientation.